### PR TITLE
Improve layerable hierarchy

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -53,8 +53,11 @@
             - wfsplugin : edso
             - horae : mantaer
 
-        refactoring : we should reorganize layerable interface and subclasses a bit
+        refactoring :
+            - we should reorganize layerable interface and subclasses a bit
             so that we have less code smell like if layerable instance of ...
+            - if possible simplify PlugIn hierarchy by merging AbstractPlugIn
+            and AbstractUiPlugIn (as well as threaded version)
 
         redundancy : clean code, remove redundancy (started)
 

--- a/src/com/vividsolutions/jump/workbench/model/AbstractLayerable.java
+++ b/src/com/vividsolutions/jump/workbench/model/AbstractLayerable.java
@@ -39,7 +39,8 @@ import com.vividsolutions.jump.util.LangUtil;
  * 
  * @see Layerable
  */
-public abstract class AbstractLayerable implements Layerable {
+public abstract class AbstractLayerable implements Layerable, LayerManagerProxy {
+
   private LayerManager layerManager;
 
   private String name;
@@ -154,8 +155,8 @@ public abstract class AbstractLayerable implements Layerable {
   }
 
   // <<TODO:REFACTORING>> Move Visible to LayerSelection, since it should be a
-  // property
-  // of the view, not the model [Jon Aquino]
+  // property of the view, not the model [Jon Aquino]
+  // isVisible has been there from the beginning and I can't see a better place [mmichaud]
   public boolean isVisible() {
     return visible;
   }
@@ -239,4 +240,5 @@ public abstract class AbstractLayerable implements Layerable {
     fireAppearanceChanged();
     return this;
   }
+
 }

--- a/src/com/vividsolutions/jump/workbench/model/AbstractLayerable.java
+++ b/src/com/vividsolutions/jump/workbench/model/AbstractLayerable.java
@@ -42,20 +42,16 @@ import com.vividsolutions.jump.util.LangUtil;
 public abstract class AbstractLayerable implements Layerable, LayerManagerProxy {
 
   private LayerManager layerManager;
-
   private String name;
-
   private boolean visible = true;
   private boolean editable = false;
   private boolean selectable = true;
   private boolean readonly = false;
-
   private boolean scaleDependentRenderingEnabled = false;
 
   // When working with scale, the max is less than the min. [Jon Aquino
   // 2005-03-01]
   private Double minScale = null;
-
   private Double maxScale = null;
 
   /**
@@ -86,10 +82,12 @@ public abstract class AbstractLayerable implements Layerable, LayerManagerProxy 
     }
   }
 
+  @Override
   public void setLayerManager(LayerManager layerManager) {
     this.layerManager = layerManager;
   }
 
+  @Override
   public LayerManager getLayerManager() {
     return layerManager;
   }
@@ -116,10 +114,12 @@ public abstract class AbstractLayerable implements Layerable, LayerManagerProxy 
     fireLayerChanged(LayerEventType.APPEARANCE_CHANGED);
   }
 
+  @Override
   public String getName() {
     return name;
   }
 
+  @Override
   public void setName(String name) {
     this.name = name;
     fireLayerChanged(LayerEventType.METADATA_CHANGED);
@@ -133,6 +133,15 @@ public abstract class AbstractLayerable implements Layerable, LayerManagerProxy 
     }
   }
 
+  // <<TODO:REFACTORING>> Move Visible to LayerSelection, since it should be a
+  // property of the view, not the model [Jon Aquino]
+  // isVisible has been there from the beginning and I can't see a better place [mmichaud]
+  @Override
+  public boolean isVisible() {
+    return visible;
+  }
+
+  @Override
   public void setVisible(boolean visible) {
     if (this.visible == visible) {
       return;
@@ -145,6 +154,7 @@ public abstract class AbstractLayerable implements Layerable, LayerManagerProxy 
    * Editability is not enforced; all parties are responsible for heeding this
    * flag.
    */
+  @Override
   public void setEditable(boolean editable) {
     if (this.editable == editable) {
       return;
@@ -154,13 +164,7 @@ public abstract class AbstractLayerable implements Layerable, LayerManagerProxy 
     fireLayerChanged(LayerEventType.METADATA_CHANGED);
   }
 
-  // <<TODO:REFACTORING>> Move Visible to LayerSelection, since it should be a
-  // property of the view, not the model [Jon Aquino]
-  // isVisible has been there from the beginning and I can't see a better place [mmichaud]
-  public boolean isVisible() {
-    return visible;
-  }
-
+  @Override
   public boolean isEditable() {
     return editable;
   }
@@ -169,6 +173,7 @@ public abstract class AbstractLayerable implements Layerable, LayerManagerProxy 
    * @return true if this layer should always be 'readonly' I.e.: The layer
    *         should never have the editable field set to true.
    */
+  @Override
   public boolean isReadonly() {
     return readonly;
   }
@@ -176,6 +181,7 @@ public abstract class AbstractLayerable implements Layerable, LayerManagerProxy 
   /**
    * Set whether this layer can be made editable.
    */
+  @Override
   public void setReadonly(boolean value) {
     readonly = value;
   }
@@ -183,6 +189,7 @@ public abstract class AbstractLayerable implements Layerable, LayerManagerProxy 
   /**
    * @return true if features in this layer can be selected.
    */
+  @Override
   public boolean isSelectable() {
     return selectable;
   }
@@ -190,21 +197,24 @@ public abstract class AbstractLayerable implements Layerable, LayerManagerProxy 
   /**
    * Set whether or not features in this layer can be selected.
    * 
-   * @param value
-   *          true if features in this layer can be selected
+   * @param value true if features in this layer can be selected
    */
+  @Override
   public void setSelectable(boolean value) {
     selectable = value;
   }
 
+  @Override
   public String toString() {
     return getName();
   }
 
+  @Override
   public Double getMaxScale() {
     return maxScale;
   }
 
+  @Override
   public Layerable setMaxScale(Double maxScale) {
     if (LangUtil.bothNullOrEqual(this.maxScale, maxScale)) {
       return this;
@@ -214,10 +224,12 @@ public abstract class AbstractLayerable implements Layerable, LayerManagerProxy 
     return this;
   }
 
+  @Override
   public Double getMinScale() {
     return minScale;
   }
 
+  @Override
   public Layerable setMinScale(Double minScale) {
     if (LangUtil.bothNullOrEqual(this.minScale, minScale)) {
       return this;
@@ -227,10 +239,12 @@ public abstract class AbstractLayerable implements Layerable, LayerManagerProxy 
     return this;
   }
 
+  @Override
   public boolean isScaleDependentRenderingEnabled() {
     return scaleDependentRenderingEnabled;
   }
 
+  @Override
   public Layerable setScaleDependentRenderingEnabled(
       boolean scaleDependentRenderingEnabled) {
     if (this.scaleDependentRenderingEnabled == scaleDependentRenderingEnabled) {

--- a/src/com/vividsolutions/jump/workbench/model/GeoReferencedLayerable.java
+++ b/src/com/vividsolutions/jump/workbench/model/GeoReferencedLayerable.java
@@ -1,0 +1,50 @@
+package com.vividsolutions.jump.workbench.model;
+
+import com.vividsolutions.jump.util.Blackboard;
+import org.locationtech.jts.geom.Envelope;
+import org.openjump.core.ccordsys.utils.SRSInfo;
+
+
+/**
+ * Add a parent class to georeferenced layers having SRSInfo and Envelope
+ * @since 2.0
+ */
+public abstract class GeoReferencedLayerable extends AbstractLayerable implements Disposable {
+
+  private final Blackboard blackboard = new Blackboard();
+
+  private Envelope envelope;
+
+  private SRSInfo srsInfo;
+
+  /**
+   * Called by Java2XML
+   */
+  public GeoReferencedLayerable() {
+  }
+
+  public GeoReferencedLayerable(String name, LayerManager layerManager) {
+    super(name, layerManager);
+  }
+
+  @Override
+  public Blackboard getBlackboard() {
+    return blackboard;
+  }
+
+  public Envelope getEnvelope() {
+    return envelope;
+  }
+
+  public void setEnvelope(Envelope envelope) {
+    this.envelope = envelope;
+  }
+
+  public SRSInfo getSrsInfo() {
+    return srsInfo;
+  }
+
+  public void setSrsInfo(SRSInfo srsInfo) {
+    this.srsInfo = srsInfo;
+  }
+}

--- a/src/com/vividsolutions/jump/workbench/model/LayerView.java
+++ b/src/com/vividsolutions/jump/workbench/model/LayerView.java
@@ -81,12 +81,12 @@ public class LayerView extends Layer {
 
     observableFeatureCollection.add(new ObservableFeatureCollection.Listener() {
 
-      public void featuresAdded(Collection features) {
+      public void featuresAdded(Collection<Feature> features) {
         getLayerManager().fireFeaturesChanged(features, FeatureEventType.ADDED,
                 LayerView.this);
       }
 
-      public void featuresRemoved(Collection features) {
+      public void featuresRemoved(Collection<Feature> features) {
         getLayerManager().fireFeaturesChanged(features,
                 FeatureEventType.DELETED, LayerView.this);
       }

--- a/src/com/vividsolutions/jump/workbench/model/ObservableFeatureCollection.java
+++ b/src/com/vividsolutions/jump/workbench/model/ObservableFeatureCollection.java
@@ -105,9 +105,9 @@ public class ObservableFeatureCollection extends FeatureCollectionWrapper {
      * FeatureCollection.
      */
     public interface Listener {
-        void featuresAdded(Collection features);
+        void featuresAdded(Collection<Feature> features);
 
-        void featuresRemoved(Collection features);
+        void featuresRemoved(Collection<Feature> features);
     }
 
 }

--- a/src/com/vividsolutions/jump/workbench/model/WMSLayer.java
+++ b/src/com/vividsolutions/jump/workbench/model/WMSLayer.java
@@ -44,6 +44,7 @@ import java.util.List;
 
 import javax.swing.JButton;
 
+import com.vividsolutions.wms.*;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.util.Assert;
 import com.vividsolutions.jump.util.Blackboard;
@@ -51,15 +52,14 @@ import com.vividsolutions.jump.workbench.Logger;
 import com.vividsolutions.jump.workbench.ui.LayerNameRenderer;
 import com.vividsolutions.jump.workbench.ui.LayerViewPanel;
 import com.vividsolutions.jump.workbench.ui.renderer.RenderingManager;
-import com.vividsolutions.wms.BoundingBox;
-import com.vividsolutions.wms.MapLayer;
-import com.vividsolutions.wms.MapRequest;
-import com.vividsolutions.wms.WMService;
+import org.openjump.core.ccordsys.utils.SRSInfo;
 
 /**
  * A Layerable that retrieves images from a Web Map Server.
  */
-public class WMSLayer extends AbstractLayerable implements Cloneable {
+public class WMSLayer
+        extends GeoReferencedLayerable
+        implements Cloneable {
 
   private String format;
 
@@ -73,7 +73,7 @@ public class WMSLayer extends AbstractLayerable implements Cloneable {
 
   private String wmsVersion = WMService.WMS_1_1_1;
 
-  private Reference oldImage;
+  private Reference<Image> oldImage;
   private URL oldURL;
 
   /**
@@ -216,6 +216,7 @@ public class WMSLayer extends AbstractLayerable implements Cloneable {
 
   public void setSRS(String srs) {
     this.srs = srs;
+    setSrsInfo(new SRSInfo().setCode(srs).complete());
   }
 
   public String getSRS() {

--- a/src/com/vividsolutions/jump/workbench/model/WMSLayer.java
+++ b/src/com/vividsolutions/jump/workbench/model/WMSLayer.java
@@ -61,19 +61,17 @@ public class WMSLayer
         extends GeoReferencedLayerable
         implements Cloneable {
 
-  private String format;
+  private WMService service;
+  private String wmsVersion = WMService.WMS_1_3_0;
 
   private List<String> layerNames = new ArrayList<>();
-
   private String srs;
-
+  private String format;
+  private MapStyle style;
+  private String moreParameters;
   private int alpha = 255;
 
-  private WMService service;
-
-  private String wmsVersion = WMService.WMS_1_1_1;
-
-  private Reference<Image> oldImage;
+  private Reference oldImage;
   private URL oldURL;
 
   /**
@@ -159,7 +157,7 @@ public class WMSLayer
 
     // look if last request equals new one.
     // if it does, take the image from the cache.
-    if (oldURL == null || !newURL.equals(oldURL) || oldImage == null
+    if (!newURL.equals(oldURL) || oldImage == null
         || (image = (Image) oldImage.get()) == null) {
       image = request.getImage();
       MediaTracker mt = new MediaTracker(new JButton());
@@ -183,8 +181,8 @@ public class WMSLayer
 
   public MapRequest createRequest(LayerViewPanel panel) throws IOException {
     MapRequest request = getService().createMapRequest();
-    request.setBoundingBox(toBoundingBox(srs, panel.getViewport()
-        .getEnvelopeInModelCoordinates()));
+    request.setBoundingBox(toBoundingBox(srs,
+        panel.getViewport().getEnvelopeInModelCoordinates()));
     request.setFormat(format);
     request.setImageWidth(panel.getWidth());
     request.setImageHeight(panel.getHeight());
@@ -234,7 +232,7 @@ public class WMSLayer
     layerNames.clear();
   }
 
-  private Blackboard blackboard = new Blackboard();
+  private final Blackboard blackboard = new Blackboard();
 
   private String serverURL;
 

--- a/src/com/vividsolutions/wms/MapRequest.java
+++ b/src/com/vividsolutions/wms/MapRequest.java
@@ -106,7 +106,7 @@ public class MapRequest extends AbstractWMSRequest{
      * list should be a String which is the name of a layer.
      * @return the list of layer names to be requested
      */
-    public List getLayerNames() {
+    public List<String> getLayerNames() {
         return Collections.unmodifiableList(layerNames);
     }
 

--- a/src/org/openjump/core/ccordsys/utils/SRSInfo.java
+++ b/src/org/openjump/core/ccordsys/utils/SRSInfo.java
@@ -11,7 +11,8 @@ import org.openjump.core.ccordsys.Unit;
 /**
  * Small container for SRS information. This class does not contain all
  * information to perform coordinate transformation, but enough to return
- * metadata about SRS code or map unit
+ * metadata about SRS code or map unit.
+ * Example : new SRSInfo().setCode("2154").complete();
  */
 public class SRSInfo {
 
@@ -28,8 +29,8 @@ public class SRSInfo {
                                 // path)
     private Registry registry = EPSG; // The registry in which this SRS is
                                       // referenced
-    private String code = UNDEFINED; // The code of the SRS
-    private String description = ""; // The name or description of the SRS
+    private String code = UNDEFINED;  // The code of the SRS
+    private String description = "";  // The name or description of the SRS
     private Unit unit = Unit.UNKNOWN; // The unit used by this SRS
 
     public SRSInfo() {
@@ -105,7 +106,7 @@ public class SRSInfo {
         return this;
     }
 
-    public void complete() throws UnsupportedEncodingException {
+    public SRSInfo complete() {
         SRSInfo sridTableInfo = SridLookupTable.getSrsAndUnitFromCode(code);
         if (sridTableInfo.getCode().equals(UNDEFINED)) {
             sridTableInfo = SridLookupTable.getSrsAndUnitFromName(description);
@@ -116,6 +117,8 @@ public class SRSInfo {
             unit = sridTableInfo.getUnit();
         }
         registry = guessRegistry(code);
+
+        return this;
     }
 
     @Override

--- a/src/org/openjump/core/rasterimage/AddRasterImageLayerWizard.java
+++ b/src/org/openjump/core/rasterimage/AddRasterImageLayerWizard.java
@@ -9,11 +9,10 @@ import java.io.IOException;
 
 import javax.imageio.ImageIO;
 
+import com.vividsolutions.jump.workbench.Logger;
 import org.openjump.core.ccordsys.utils.ProjUtils;
 import org.openjump.core.ccordsys.utils.SRSInfo;
 import org.openjump.core.ui.plugin.file.OpenRecentPlugIn;
-import org.openjump.core.ui.plugin.file.open.ChooseProjectPanel;
-//import org.openjump.core.ui.plugin.layer.pirolraster.LoadSextanteRasterImagePlugIn;
 import org.openjump.core.ui.plugin.layer.pirolraster.RasterImageWizardPanel;
 import org.openjump.core.ui.swing.wizard.AbstractWizardGroup;
 import org.openjump.io.PropertiesHandler;
@@ -26,7 +25,6 @@ import com.vividsolutions.jump.task.TaskMonitor;
 import com.vividsolutions.jump.task.TaskMonitorV2Util;
 import com.vividsolutions.jump.workbench.WorkbenchContext;
 import com.vividsolutions.jump.workbench.model.Category;
-import com.vividsolutions.jump.workbench.model.LayerManager;
 import com.vividsolutions.jump.workbench.model.Layerable;
 import com.vividsolutions.jump.workbench.model.StandardCategoryNames;
 import com.vividsolutions.jump.workbench.ui.GUIUtil;
@@ -40,7 +38,7 @@ public class AddRasterImageLayerWizard extends AbstractWizardGroup {
     public static final String KEY = AddRasterImageLayerWizard.class.getName();
 
     private final WorkbenchContext workbenchContext;
-    private ChooseProjectPanel chooseProjectPanel;
+    //private ChooseProjectPanel chooseProjectPanel;
     private SelectRasterImageFilesPanel selectFilesPanel;
 
     private File[] files;
@@ -55,7 +53,7 @@ public class AddRasterImageLayerWizard extends AbstractWizardGroup {
     protected boolean zoomToInsertedImage = false;
     private String imageFileName = "";
     private String cachedLayer = "default-layer-name";
-    public static String KEY_PATH = "path";
+    //public static String KEY_PATH = "path";
 
     // ------
 
@@ -65,7 +63,7 @@ public class AddRasterImageLayerWizard extends AbstractWizardGroup {
                 IconLoader.icon("mapSv2_13.png"),
                 SelectRasterImageFilesPanel.KEY);
         this.workbenchContext = workbenchContext;
-        RasterImageLayer.setWorkbenchContext(workbenchContext);
+        //RasterImageLayer.setWorkbenchContext(workbenchContext);
     }
 
     public AddRasterImageLayerWizard(final WorkbenchContext workbenchContext,
@@ -115,7 +113,7 @@ public class AddRasterImageLayerWizard extends AbstractWizardGroup {
 
     private void open(File[] files, TaskMonitor monitor) {
       monitor.allowCancellationRequests();
-      LayerManager layerManager = workbenchContext.getLayerManager();
+      //LayerManager layerManager = workbenchContext.getLayerManager();
 
         for (int i = 0; i < files.length; i++) {
           if (TaskMonitorV2Util.isCancelRequested(monitor))
@@ -174,7 +172,7 @@ public class AddRasterImageLayerWizard extends AbstractWizardGroup {
     }
 
     private void addImage(WorkbenchContext context, Envelope envelope,
-            Point imageDimensions) throws NoninvertibleTransformException {
+            Point imageDimensions) {
 
         if (context.getTask() == null) {
             context.getWorkbench().getFrame().addTaskFrame();
@@ -190,7 +188,8 @@ public class AddRasterImageLayerWizard extends AbstractWizardGroup {
                     .getLayerNamePanel().getSelectedCategories().toArray()[0])
                     .getName();
         } catch (final RuntimeException e1) {
-            // logger.printDebug(e1.getMessage());
+            Logger.warn("AddRasterImageLayerWizard.addImage: " +
+                    "error trying to get the name of the currently selected category", e1);
         }
 
         final int layersAsideImage = context.getLayerManager()
@@ -208,7 +207,7 @@ public class AddRasterImageLayerWizard extends AbstractWizardGroup {
             // rLayer.setSRSInfo(ProjUtils.getSRSInfoFromLayerSource(rLayer));
             final SRSInfo srsInfo = ProjUtils.getSRSInfoFromLayerSource(rLayer);
             srsInfo.complete();
-            rLayer.setSRSInfo(srsInfo);
+            rLayer.setSrsInfo(srsInfo);
         } catch (final Exception e1) {
             e1.printStackTrace();
         }
@@ -229,8 +228,8 @@ public class AddRasterImageLayerWizard extends AbstractWizardGroup {
         // metadata. Those datas are saved into OJ project file and can be
         // reused
         // by the plugins
-        mih.addMetaInformation("srid", rLayer.getSRSInfo().getCode());
-        mih.addMetaInformation("srid-location", rLayer.getSRSInfo().getSource());
+        mih.addMetaInformation("srid", rLayer.getSrsInfo().getCode());
+        mih.addMetaInformation("srid-location", rLayer.getSrsInfo().getSource());
 
         // ###################################
         context.getLayerManager().addLayerable(catName, rLayer);
@@ -325,7 +324,7 @@ public class AddRasterImageLayerWizard extends AbstractWizardGroup {
                 env = new Envelope(upperLeft, lowerRight);
             }
 
-            if (!isGeoTiff || env == null) {
+            if (!isGeoTiff) {
                 // logger.printDebug(PirolPlugInMessages.getString("no-worldfile-found"));
 
                 final Viewport viewport = context.getLayerViewPanel()
@@ -360,7 +359,7 @@ public class AddRasterImageLayerWizard extends AbstractWizardGroup {
                         context.getWorkbench().getFrame(),
                         I18N.getMessage(
                                 "org.openjump.core.rasterimage.AddRasterImageLayerWizard.no-worldfile-found-message",
-                                new Object[] { fil.getName() })
+                                fil.getName())
                         /*
                          * I18N.get("RasterImagePlugIn.34") +
                          * this.worldFileHandler.getWorldFileName() +
@@ -428,7 +427,7 @@ public class AddRasterImageLayerWizard extends AbstractWizardGroup {
             final String MSG = I18N
                     .getMessage(
                             "org.openjump.core.rasterimage.AddRasterImageLayerWizard.message",
-                            new Object[] { fil.getName() });
+                            fil.getName());
             context.getWorkbench().getFrame().setStatusMessage(MSG);
 
         }

--- a/src/org/openjump/core/rasterimage/RasterImageIO.java
+++ b/src/org/openjump/core/rasterimage/RasterImageIO.java
@@ -45,7 +45,7 @@ import com.vividsolutions.jump.workbench.ui.Viewport;
  */
 public class RasterImageIO {
 
-	public ImageAndMetadata loadImage(WorkbenchContext wbContext,
+	public ImageAndMetadata loadImage(
 			String fileNameOrURL, Stats stats, Envelope viewPortEnvelope,
 			Resolution requestedRes) throws Exception {
 
@@ -292,9 +292,8 @@ public class RasterImageIO {
 			Coordinate coordinate, int band) throws Exception {
 
 		Point imageDims = getImageDimensions(fileNameOrURL);
-	//	Envelope envelope = getGeoReferencing(fileNameOrURL);
-		 Envelope envelope = getGeoReferencing(fileNameOrURL, true, new Point(
-		 		imageDims.x, imageDims.y));
+		Envelope envelope = getGeoReferencing(fileNameOrURL,
+				true, new Point(imageDims.x, imageDims.y));
 		double cellSizeX = (envelope.getMaxX() - envelope.getMinX())
 				/ imageDims.x;
 		double cellSizeY = (envelope.getMaxY() - envelope.getMinY())
@@ -417,18 +416,18 @@ public class RasterImageIO {
 		return null;
 	}
 
-	/**
-	 * Get Envelope  from file 
-	 * @param fileName
-	 * @return Envelope
-	 * @throws ReferencedImageException
-	 */
-	
-/*	public static Envelope getGeoReferencing(String fileName) throws ReferencedImageException {
-		GeoReferencedRaster	geoRaster = new  GeoReferencedRaster(new File(fileName).toURI().toString());
-	return geoRaster.getEnvelope();
-	
-	}*/
+	///**
+	// * Get Envelope  from file
+	// * @param fileName
+	// * @return Envelope
+	// * @throws ReferencedImageException
+	// */
+	//
+	///*	public static Envelope getGeoReferencing(String fileName) throws ReferencedImageException {
+	//	GeoReferencedRaster	geoRaster = new  GeoReferencedRaster(new File(fileName).toURI().toString());
+	//return geoRaster.getEnvelope();
+	//
+	//}*/
 	
 	/**
 	 * Substituted by method getGeoReferencing(String fileName)
@@ -920,16 +919,16 @@ public class RasterImageIO {
 		encoder.encode(bufferedImage);
 		tifOut.close();
 		 int bandCount = bufferedImage.getRaster().getNumBands();
-		  double minValue[] = new double[bandCount];
-	        double maxValue[] = new double[bandCount];
-	        double sum[] = new double[bandCount];
-	        double sumSquare[] = new double[bandCount];
-	        long cellsCount[] = new long[bandCount];
+		 double minValue[] = new double[bandCount];
+		 double maxValue[] = new double[bandCount];
+		 double sum[] = new double[bandCount];
+		 double sumSquare[] = new double[bandCount];
+		 long cellsCount[] = new long[bandCount];
 	        
-	        for(int b=0; b<bandCount; b++) {
-	            minValue[b] = Double.MAX_VALUE;
-	            maxValue[b] = -Double.MAX_VALUE;
-	        }
+		 for(int b=0; b<bandCount; b++) {
+		 	minValue[b] = Double.MAX_VALUE;
+		 	maxValue[b] = -Double.MAX_VALUE;
+		 }
 	        
 	        for(int r=0; r<bufferedImage.getHeight(); r++) {
 	            Raster raster2 = bufferedImage.getData(new Rectangle(0, r, bufferedImage.getWidth(), 1));

--- a/src/org/openjump/core/rasterimage/RasterImageIOUtils.java
+++ b/src/org/openjump/core/rasterimage/RasterImageIOUtils.java
@@ -24,7 +24,6 @@ import javax.media.jai.PlanarImage;
 import org.openjump.core.rasterimage.TiffTags.TiffReadingException;
 import org.openjump.core.rasterimage.sextante.OpenJUMPSextanteRasterLayer;
 import org.openjump.core.rasterimage.sextante.rasterWrappers.GridWrapperNotInterpolated;
-//import org.openjump.core.ui.plugin.layer.pirolraster.LoadSextanteRasterImagePlugIn;
 
 import org.locationtech.jts.geom.Envelope;
 import com.vividsolutions.jump.I18N;
@@ -41,8 +40,8 @@ import com.vividsolutions.jump.workbench.ui.Viewport;
  */
 public class RasterImageIOUtils {
     static Properties properties = null;
-    private static String byteOrder = "LSBFIRST";
-    private static String propertiesFile = "path";
+    private final static String byteOrder = "LSBFIRST";
+    private final static String propertiesFile = "path";
     static NumberFormat cellFormat = null;
     // public static final Double DEFAULT_NODATA = Double.valueOf(-9999.0D);
     public static double defaultNoData = -99999.0D;
@@ -56,13 +55,12 @@ public class RasterImageIOUtils {
      *            Selected Raster Image Layer (RasterImageLayer.class)
      * @param envWanted
      *            envelope wanted
-     * @throws NoninvertibleTransformException
-     *             , TiffReadingException, Exception
+     * @throws IOException if an IOException occurs in RasterImageLayer.getRasterData
+     *      or in RasterImageIO.writeImage
      */
 
     public static void saveTIF(File file, RasterImageLayer rLayer,
-            Envelope envWanted) throws NoninvertibleTransformException,
-            TiffReadingException, Exception {
+            Envelope envWanted) throws IOException {
 
         RasterImageIO rasterImageIO = new RasterImageIO();
 
@@ -183,7 +181,6 @@ public class RasterImageIOUtils {
     public static void saveASC(File outfile, PlugInContext context,
             RasterImageLayer rLayer) throws IOException {
         saveASC(outfile, context, rLayer, 0);
-        return;
     }
 
     /**
@@ -494,14 +491,14 @@ public class RasterImageIOUtils {
             }
             defaultNoData = rstLayer.getNoDataValue();
 
-            Double xcMin = Double.valueOf(rLayer.getActualImageEnvelope()
-                    .getMinX() + 0.5D * rstLayer.getLayerCellSize().x);
-            Double ycMin = Double.valueOf(rLayer.getActualImageEnvelope()
-                    .getMinY() + 0.5D * rstLayer.getLayerCellSize().y);
-            Double xcMax = Double.valueOf(rLayer.getActualImageEnvelope()
-                    .getMaxX() - 0.5D * rstLayer.getLayerCellSize().x);
-            Double ycMax = Double.valueOf(rLayer.getActualImageEnvelope()
-                    .getMaxY() - 0.5D * rstLayer.getLayerCellSize().y);
+            Double xcMin = rLayer.getActualImageEnvelope()
+                    .getMinX() + 0.5D * rstLayer.getLayerCellSize().x;
+            Double ycMin = rLayer.getActualImageEnvelope()
+                    .getMinY() + 0.5D * rstLayer.getLayerCellSize().y;
+            Double xcMax = rLayer.getActualImageEnvelope()
+                    .getMaxX() - 0.5D * rstLayer.getLayerCellSize().x;
+            Double ycMax = rLayer.getActualImageEnvelope()
+                    .getMaxY() - 0.5D * rstLayer.getLayerCellSize().y;
 
             PrintStream po = new PrintStream(out);
             po.println("DSAA");
@@ -764,8 +761,7 @@ public class RasterImageIOUtils {
      */
 
     public static void loadTIF(File file, PlugInContext context, String category)
-            throws NoninvertibleTransformException, TiffReadingException,
-            Exception {
+            throws Exception {
 
         RasterImageIO rasterImageIO = new RasterImageIO();
         Viewport viewport = context.getWorkbenchContext().getLayerViewPanel()
@@ -773,7 +769,7 @@ public class RasterImageIOUtils {
         Resolution requestedRes = RasterImageIO
                 .calcRequestedResolution(viewport);
         ImageAndMetadata imageAndMetadata = rasterImageIO.loadImage(
-                context.getWorkbenchContext(), file.getAbsolutePath(), null,
+                /*context.getWorkbenchContext(),*/ file.getAbsolutePath(), null,
                 viewport.getEnvelopeInModelCoordinates(), requestedRes);
          Point point = RasterImageIO.getImageDimensions(file.getAbsolutePath());
        Envelope env = RasterImageIO.getGeoReferencing(file.getAbsolutePath(),
@@ -814,7 +810,7 @@ public class RasterImageIOUtils {
         Resolution requestedRes = RasterImageIO
                 .calcRequestedResolution(viewport);
         ImageAndMetadata imageAndMetadata = rasterImageIO.loadImage(
-                context.getWorkbenchContext(), file.getAbsolutePath(), null,
+                /*context.getWorkbenchContext(),*/ file.getAbsolutePath(), null,
                 viewport.getEnvelopeInModelCoordinates(), requestedRes);
 
         GridFloat gf = new GridFloat(file.getAbsolutePath());
@@ -855,7 +851,7 @@ public class RasterImageIOUtils {
         Resolution requestedRes = RasterImageIO
                 .calcRequestedResolution(viewport);
         ImageAndMetadata imageAndMetadatar = rasterImageIO.loadImage(
-                context.getWorkbenchContext(), file.getAbsolutePath(), null,
+                /*context.getWorkbenchContext(),*/ file.getAbsolutePath(), null,
                 viewport.getEnvelopeInModelCoordinates(), requestedRes);
         GridAscii gf = new GridAscii(file.getAbsolutePath());
 

--- a/src/org/openjump/core/rasterimage/RasterImageLayer.java
+++ b/src/org/openjump/core/rasterimage/RasterImageLayer.java
@@ -19,16 +19,14 @@ import java.awt.image.Raster;
 import java.awt.image.renderable.ParameterBlock;
 import java.io.File;
 import java.io.IOException;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
 
 import javax.media.jai.JAI;
 
-import com.vividsolutions.jump.workbench.model.Disposable;
+import com.vividsolutions.jump.workbench.model.*;
 import org.apache.commons.imaging.ImageReadException;
 import org.apache.commons.imaging.Imaging;
-import org.openjump.core.ccordsys.utils.SRSInfo;
 import org.openjump.util.metaData.MetaDataMap;
 import org.openjump.util.metaData.ObjectContainingMetaInformation;
 
@@ -37,14 +35,9 @@ import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import com.vividsolutions.jump.I18N;
-import com.vividsolutions.jump.util.Blackboard;
 import com.vividsolutions.jump.util.Timer;
 import com.vividsolutions.jump.workbench.Logger;
 import com.vividsolutions.jump.workbench.WorkbenchContext;
-import com.vividsolutions.jump.workbench.model.AbstractLayerable;
-import com.vividsolutions.jump.workbench.model.LayerManager;
-import com.vividsolutions.jump.workbench.model.Layerable;
-import com.vividsolutions.jump.workbench.plugin.PlugInContext;
 import com.vividsolutions.jump.workbench.ui.LayerNameRenderer;
 import com.vividsolutions.jump.workbench.ui.LayerViewPanel;
 import com.vividsolutions.jump.workbench.ui.Viewport;
@@ -61,13 +54,14 @@ import com.vividsolutions.jump.workbench.ui.Viewport;
  * @version $Rev: 2509 $
  * modified: [sstein]: 16.Feb.2009 changed logger-entries to comments, used frame.warnUser
  */
-public final class RasterImageLayer extends AbstractLayerable
+// TODO ObjectContainingMetaInformation seems a bit redundant with Blackboard
+public final class RasterImageLayer extends GeoReferencedLayerable
         implements ObjectContainingMetaInformation, Disposable {
     
-    protected static Blackboard blackboard = null;
+    //protected static Blackboard blackboard = null;
     
-    protected final static String BLACKBOARD_KEY_PLUGINCONTEXT = PlugInContext.class.getName();
-    protected final static String BLACKBOARD_KEY_WORKBENCHCONTEXT = PlugInContext.class.getName();
+    //protected final static String BLACKBOARD_KEY_PLUGINCONTEXT = PlugInContext.class.getName();
+    //protected final static String BLACKBOARD_KEY_WORKBENCHCONTEXT = PlugInContext.class.getName();
     
     protected int lastImgProcessingMode = 0;
     
@@ -107,7 +101,7 @@ public final class RasterImageLayer extends AbstractLayerable
     protected BufferedImage scaledBufferedImage = null;
 
     protected Envelope actualImageEnvelope = null, visibleEnv = null, oldVisibleEnv;
-    protected Envelope originalImageEnvelope = null;
+    //protected Envelope originalImageEnvelope = null;
     
     /**
      * Flag to decide, if events are fired automatically, if the appearance (imageEnvelope, etc.) changes.<br>
@@ -153,7 +147,7 @@ public final class RasterImageLayer extends AbstractLayerable
      *@return the Envelope as string
      */
     public String getXmlEnvelope(){
-        return this.originalImageEnvelope.toString();
+        return getEnvelope().toString();
     }
 
     /**
@@ -184,14 +178,18 @@ public final class RasterImageLayer extends AbstractLayerable
      * @param imageToDisplay the image (if already loaded) or null
      * @param wholeImageEnvelope the image envelope in model (real world) coordinates
      */
-    public RasterImageLayer(String name, LayerManager layerManager, String imageFileName,
-                            BufferedImage imageToDisplay, Envelope wholeImageEnvelope) {
+    public RasterImageLayer(String name,
+                            LayerManager layerManager,
+                            String imageFileName,
+                            BufferedImage imageToDisplay,
+                            Envelope wholeImageEnvelope) {
         super(name, layerManager);
         
         getBlackboard().put(LayerNameRenderer.USE_CLOCK_ANIMATION_KEY, true);
         
         this.imageFileName = imageFileName;
-        this.originalImageEnvelope = wholeImageEnvelope;
+        setEnvelope(wholeImageEnvelope);
+        //this.originalImageEnvelope = wholeImageEnvelope;
         
         if (imageToDisplay != null)
             this.setImage(imageToDisplay);
@@ -218,7 +216,11 @@ public final class RasterImageLayer extends AbstractLayerable
      *@param newRaster the raster (if already loaded) or null
      *@param wholeImageEnvelope the image envelope in model (real world) coordinates
      */
-    public RasterImageLayer(String name, LayerManager layerManager, BufferedImage imageToDisplay, Raster newRaster, Envelope wholeImageEnvelope) {
+    public RasterImageLayer(String name,
+                            LayerManager layerManager,
+                            BufferedImage imageToDisplay,
+                            Raster newRaster,
+                            Envelope wholeImageEnvelope) {
         super(name, layerManager);
 
         if (imageToDisplay == null || newRaster == null) {
@@ -229,7 +231,8 @@ public final class RasterImageLayer extends AbstractLayerable
         getBlackboard().put(LayerNameRenderer.USE_CLOCK_ANIMATION_KEY, true);
         
         this.setNeedToKeepImage(true);
-        this.originalImageEnvelope = wholeImageEnvelope;
+        setEnvelope(wholeImageEnvelope);
+        //this.originalImageEnvelope = wholeImageEnvelope;
         
         this.setImage(imageToDisplay);
 
@@ -244,31 +247,45 @@ public final class RasterImageLayer extends AbstractLayerable
         //[sstein end]
     }
 
-    @Override
-    public Blackboard getBlackboard() {
-        if (RasterImageLayer.blackboard == null)
-            RasterImageLayer.blackboard = new Blackboard();
-        
-        return RasterImageLayer.blackboard;
-    }
+    //@Override
+    //public Blackboard getBlackboard() {
+    //    if (getBlackboard() == null)
+    //        RasterImageLayer.blackboard = new Blackboard();
+    //
+    //    return RasterImageLayer.blackboard;
+    //}
 
     @Override
     public Object clone() throws CloneNotSupportedException {
-        RasterImageLayer raster = null;
-        try {
-            raster = new RasterImageLayer(getName(), getLayerManager(), getImageFileName(),
-                    getImageForDisplay(), new Envelope(getWholeImageEnvelope()));
-            raster.needToKeepImage = needToKeepImage;
-        } catch (Exception ex) {
-            Logger.error(ex);
-        }
-        // clone must produce a layerable with the same name (as for Layer) not a unique name
-        if (raster != null) {
-            raster.getLayerManager().setFiringEvents(false);
-            raster.setName(getName());
-            raster.getLayerManager().setFiringEvents(true);
-        }
-        return raster;
+        return (imageFileName == null) ?
+                new RasterImageLayer(
+                        getName(),
+                        getLayerManager(),
+                        getImage(),
+                        getActualRasterData(),
+                        getEnvelope())
+                : new RasterImageLayer(
+                        getName(),
+                        getLayerManager(),
+                        getImageFileName(),
+                        getImage(),
+                        getEnvelope());
+        //RasterImageLayer raster = null;
+        //try {
+        //    BufferedImage im = image == null ? getImageForDisplay() : image;
+        //    raster = new RasterImageLayer(getName(), getLayerManager(), getImageFileName(),
+        //            getImageForDisplay(), new Envelope(getWholeImageEnvelope()));
+        //    raster.needToKeepImage = needToKeepImage;
+        //} catch (Exception ex) {
+        //    Logger.error(ex);
+        //}
+        //// clone must produce a layerable with the same name (as for Layer) not a unique name
+        //if (raster != null) {
+        //    raster.getLayerManager().setFiringEvents(false);
+        //    raster.setName(getName());
+        //    raster.getLayerManager().setFiringEvents(true);
+        //}
+        //return raster;
     }
     
     /**
@@ -376,7 +393,7 @@ public final class RasterImageLayer extends AbstractLayerable
                     System.out.println("Reload image");
                 }
                 // Load the part of the image intersecting the viewport and setting this.image
-                reLoadImage();
+                reLoadImage(layerViewPanel);
                 if(image == null) {
                     // If image does not intersect viewport, it is null
                     return null;
@@ -391,6 +408,7 @@ public final class RasterImageLayer extends AbstractLayerable
 
                 // Apply symbology to this.image
                 imageToDraw = stretchImageValuesForDisplay();
+                layerViewPanel.getViewport().update();
                 setImage(imageToDraw);
 
                 //if(getCommittedMemory() + minRamToKeepFree < availRAM){
@@ -408,7 +426,7 @@ public final class RasterImageLayer extends AbstractLayerable
                 if (scaledBufferedImage == null || scaleXImg2Canvas != oldScaleXImg2Canvas ||
                         !RasterImageLayer.tilesAreNotNullAndCongruent( visibleEnv, oldVisibleEnv)){
 
-                    scaledBufferedImage = getVisiblePartOfTheImage( getImageForDisplay(), imagePart );
+                    scaledBufferedImage = getVisiblePartOfTheImage( getImageForDisplay(layerViewPanel), imagePart );
 
                     if (scaledBufferedImage != null) {
                         // avoid an 1 pixel by 1 pixel image to get scaled to thousands by thousands pixels causing an out of memory error
@@ -492,30 +510,32 @@ public final class RasterImageLayer extends AbstractLayerable
         }
     }
     
-    public void reLoadImage() throws Exception {
+    public void reLoadImage(LayerViewPanel layerViewPanel) throws Exception {
         
         //if (image == null && !needToKeepImage){
         
         RasterImageIO rasterImageIO = new RasterImageIO();
 
-        Viewport viewport = getWorkbenchContext().getLayerViewPanel().getViewport();
-        if(!viewport.getEnvelopeInModelCoordinates().intersects(originalImageEnvelope) &&
-                getWorkbenchContext().getLayerManager().getLayerables(Layerable.class).isEmpty()) {
-            viewport.zoom(originalImageEnvelope);
+        Viewport viewport = layerViewPanel.getViewport();
+        if(!viewport.getEnvelopeInModelCoordinates().intersects(getEnvelope())
+                && layerViewPanel.getLayerManager().getLayerables(Layerable.class).isEmpty()
+        ) {
+            viewport.zoom(getEnvelope());
         }
 
         Resolution requestedRes = RasterImageIO.calcRequestedResolution(viewport);
         long start = Timer.milliSecondsSince(0);
         Logger.debug("Try reading "+getName());
         // Get the part of the image intersecting the viewport
-        ImageAndMetadata imageAndMetadata = rasterImageIO.loadImage(getWorkbenchContext(), imageFileName, stats, viewport.getEnvelopeInModelCoordinates(), requestedRes);
+        ImageAndMetadata imageAndMetadata = rasterImageIO.loadImage(imageFileName,
+                stats, viewport.getEnvelopeInModelCoordinates(), requestedRes);
         Logger.debug("Reading '"+getName()+"' took "+Timer.secondsSinceString(start)+"s.");
         metadata = imageAndMetadata.getMetadata();
         image = imageAndMetadata.getImage();
         numBands = metadata.getStats().getBandCount();
         noDataValue = imageAndMetadata.getMetadata().getNoDataValue();
         stats = imageAndMetadata.getMetadata().getStats();
-        originalImageEnvelope = imageAndMetadata.getMetadata().getOriginalImageEnvelope();
+        setEnvelope(imageAndMetadata.getMetadata().getOriginalImageEnvelope());
         actualImageEnvelope = imageAndMetadata.getMetadata().getActualEnvelope();
         originalCellSize = imageAndMetadata.getMetadata().getOriginalCellSize();        
         actualCellSize = imageAndMetadata.getMetadata().getActualCellSize();
@@ -525,16 +545,16 @@ public final class RasterImageLayer extends AbstractLayerable
         }
     }
     
-    /**
-     * use this to assign the raster data again
-     * the method is called from  getRasterData();
-     */
-    public void reLoadImageButKeepImageForDisplay() throws Exception {
-       BufferedImage pi = getImageForDisplay();
-       //[sstein 24.Sept.2010] commented out:
-       //PlanarImage dontNeedThisImage = RasterImageLayer.loadImage( context, imageFileName); //causes error for .clone()
-       this.setImage(pi);
-    }
+    ///**
+    // * use this to assign the raster data again
+    // * the method is called from  getRasterData();
+    // */
+    //public void reLoadImageButKeepImageForDisplay() throws Exception {
+    //   BufferedImage pi = getImageForDisplay(layerViewPanel);
+    //   //[sstein 24.Sept.2010] commented out:
+    //   //PlanarImage dontNeedThisImage = RasterImageLayer.loadImage( context, imageFileName); //causes error for .clone()
+    //   this.setImage(pi);
+    //}
     
     protected BufferedImage stretchImageValuesForDisplay() throws NoninvertibleTransformException{
 
@@ -644,7 +664,7 @@ public final class RasterImageLayer extends AbstractLayerable
      * @return Envelope with the real world coordinates of the image
      */
     public Envelope getWholeImageEnvelope() {
-        return originalImageEnvelope;
+        return getEnvelope();
     }
     
     public Envelope getActualImageEnvelope() {
@@ -657,8 +677,8 @@ public final class RasterImageLayer extends AbstractLayerable
      * @param envelope the Envelope
      */
     private void setWholeImageEnvelope(Envelope envelope) {
-        originalImageEnvelope = envelope;
-        
+        setEnvelope(envelope);
+
         forceTotalRepaint();
         
         if (this.isFiringAppearanceEvents())
@@ -679,11 +699,11 @@ public final class RasterImageLayer extends AbstractLayerable
      *@return the Envelope as string
      */
     public String getXmlWholeImageEnvelope(){
-        return this.originalImageEnvelope.toString();
+        return getEnvelope().toString();
     }
     
     public String getXmlActualImageEnvelope() {
-        return this.actualImageEnvelope.toString();
+        return actualImageEnvelope.toString();
     }
     
     /**
@@ -731,7 +751,7 @@ public final class RasterImageLayer extends AbstractLayerable
      * @return return the imageEnvelope (= bounding box) as a geometry,
      */
     public Geometry getWholeImageEnvelopeAsGeometry(){
-        return new GeometryFactory().toGeometry(originalImageEnvelope);
+        return new GeometryFactory().toGeometry(getEnvelope());
     }
     
     public Geometry getActualImageEnvelopeAsGeometry(){
@@ -844,7 +864,8 @@ public final class RasterImageLayer extends AbstractLayerable
         return scaleImage(toBeScaled, (float)XscaleImg2Canvas, (float)Math.abs(YscaleImg2Canvas) );
 
     }
-    
+
+    /*
     public BufferedImage getTileAsImage( Envelope wantedEnvelope ) throws Exception{
 
         double imgWidth = image.getWidth();
@@ -919,17 +940,19 @@ public final class RasterImageLayer extends AbstractLayerable
         this.clearImageAndRaster(false);
         return result;
     }
+    */
+
     
-    protected WorkbenchContext getWorkbenchContext(){
-        return (WorkbenchContext)this.getBlackboard().get(BLACKBOARD_KEY_WORKBENCHCONTEXT);
-    }
+    //protected WorkbenchContext getWorkbenchContext(){
+    //    return (WorkbenchContext)this.getBlackboard().get(BLACKBOARD_KEY_WORKBENCHCONTEXT);
+    //}
     
-    public static void setWorkbenchContext(WorkbenchContext wContext){
-        if (blackboard==null)
-            blackboard = new Blackboard();
-        
-        blackboard.put(BLACKBOARD_KEY_WORKBENCHCONTEXT, wContext);
-    }
+    //public static void setWorkbenchContext(WorkbenchContext wContext){
+    //    if (blackboard==null)
+    //        blackboard = new Blackboard();
+    //
+    //    blackboard.put(BLACKBOARD_KEY_WORKBENCHCONTEXT, wContext);
+    //}
     
     public Rectangle getDrawingRectangle( double imgWidth, double imgHeight, Envelope imageEnv, Viewport viewport ) throws NoninvertibleTransformException{
         
@@ -1068,9 +1091,9 @@ public final class RasterImageLayer extends AbstractLayerable
      * returns the image, this can be modified - i.e. is just a representation. 
      * @return the image
      */
-    public BufferedImage getImageForDisplay() throws Exception {
+    public BufferedImage getImageForDisplay(LayerViewPanel layerViewPanel) throws Exception {
         if (image == null)
-            reLoadImage();
+            reLoadImage(layerViewPanel);
         return image;
     }
     
@@ -1348,7 +1371,7 @@ public final class RasterImageLayer extends AbstractLayerable
         
         double imgWidth = origImageWidth;
         double imgHeight = origImageHeight;
-        Envelope imageEnv = originalImageEnvelope;
+        Envelope imageEnv = getEnvelope();
         
         double minVisibleX = Math.max(envelope.getMinX(), imageEnv.getMinX());
         double minVisibleY = Math.max(envelope.getMinY(), imageEnv.getMinY());
@@ -1458,11 +1481,11 @@ public final class RasterImageLayer extends AbstractLayerable
 
     public Double getCellValue(double coordX, double coordY, int band) throws IOException {
         
-        double cellSizeX = (originalImageEnvelope.getMaxX() - originalImageEnvelope.getMinX()) / origImageWidth;
-        double cellSizeY = (originalImageEnvelope.getMaxY() - originalImageEnvelope.getMinY()) / origImageHeight;
+        double cellSizeX = (getEnvelope().getMaxX() - getEnvelope().getMinX()) / origImageWidth;
+        double cellSizeY = (getEnvelope().getMaxY() - getEnvelope().getMinY()) / origImageHeight;
         
-        int col = (int) Math.floor((coordX - originalImageEnvelope.getMinX()) / cellSizeX);
-        int row = origImageHeight - (int) Math.floor((coordY - originalImageEnvelope.getMinY()) / cellSizeY) - 1;
+        int col = (int) Math.floor((coordX - getEnvelope().getMinX()) / cellSizeX);
+        int row = origImageHeight - (int) Math.floor((coordY - getEnvelope().getMinY()) / cellSizeY) - 1;
         
         if(col <0 || col >= origImageWidth || row <0 || row >= origImageHeight) return null;
 
@@ -1516,10 +1539,10 @@ public final class RasterImageLayer extends AbstractLayerable
         this.symbology = symbology;
         symbologyChanged = true;
         scaledBufferedImage = null;
-        LayerViewPanel layerViewPanel = getWorkbenchContext().getLayerViewPanel();
-        if(layerViewPanel != null) {
-            layerViewPanel.getViewport().update();
-        }
+        //LayerViewPanel layerViewPanel = getWorkbenchContext().getLayerViewPanel();
+        //if(layerViewPanel != null) {
+        //    layerViewPanel.getViewport().update();
+        //}
     }
 
     public Raster getActualRasterData() {
@@ -1565,14 +1588,14 @@ public final class RasterImageLayer extends AbstractLayerable
     }
    
     //[Giuseppe Aruta 04/01/2017] SRS info for RasterImageLayer.class
-    private SRSInfo srsInfo;
+    //private SRSInfo srsInfo;
 
-    public SRSInfo getSRSInfo() {
-        return srsInfo;
-    }
+    //public SRSInfo getSRSInfo() {
+    //    return srsInfo;
+    //}
 
-    public void setSRSInfo(SRSInfo srs) {
-        this.srsInfo = srs;
-    }
+    //public void setSRSInfo(SRSInfo srs) {
+    //    this.srsInfo = srs;
+    //}
     
 }

--- a/src/org/openjump/core/ui/plugin/file/open/OpenProjectWizard.java
+++ b/src/org/openjump/core/ui/plugin/file/open/OpenProjectWizard.java
@@ -433,7 +433,7 @@ public class OpenProjectWizard extends AbstractWizardGroup {
         Viewport viewport = context.getLayerViewPanel().getViewport();
         Resolution requestedRes = RasterImageIO
                 .calcRequestedResolution(viewport);
-        ImageAndMetadata imageAndMetadata = rasterImageIO.loadImage(context,
+        ImageAndMetadata imageAndMetadata = rasterImageIO.loadImage(/*context,*/
                 ril.getImageFileName(), null,
                 viewport.getEnvelopeInModelCoordinates(), requestedRes);
 
@@ -442,7 +442,7 @@ public class OpenProjectWizard extends AbstractWizardGroup {
         // [Giuseppe Aruta 2017/11/13] Since raster file is reloaded we
         // detect raster and SRS info and store them as metadata.
         try {
-            ril.setSRSInfo(ProjUtils.getSRSInfoFromLayerSource(ril));
+            ril.setSrsInfo(ProjUtils.getSRSInfoFromLayerSource(ril));
         } catch (Exception e1) {
             e1.printStackTrace();
         }
@@ -456,11 +456,11 @@ public class OpenProjectWizard extends AbstractWizardGroup {
                 .getWholeImageEnvelope().getWidth());
         mih.addMetaInformation(I18N.get("real-world-height"), ril
                 .getWholeImageEnvelope().getHeight());
-        mih.addMetaInformation("srid", ril.getSRSInfo().getCode());
-        if (ril.getSRSInfo().getCode().equals("0")) {
+        mih.addMetaInformation("srid", ril.getSrsInfo().getCode());
+        if (ril.getSrsInfo().getCode().equals("0")) {
             mih.addMetaInformation("srid-location", "");
         } else {
-            mih.addMetaInformation("srid-location", ril.getSRSInfo()
+            mih.addMetaInformation("srid-location", ril.getSrsInfo()
                     .getSource());
         }
 

--- a/src/org/openjump/core/ui/plugin/layer/pirolraster/ExtractSelectedPartOfImage.java
+++ b/src/org/openjump/core/ui/plugin/layer/pirolraster/ExtractSelectedPartOfImage.java
@@ -182,7 +182,7 @@ public class ExtractSelectedPartOfImage extends AbstractPlugIn {
         Resolution requestedRes = RasterImageIO
                 .calcRequestedResolution(viewport);
         ImageAndMetadata imageAndMetadata = rasterImageIO.loadImage(
-                context.getWorkbenchContext(), outFile.getAbsolutePath(), null,
+                /*context.getWorkbenchContext(),*/ outFile.getAbsolutePath(), null,
                 viewport.getEnvelopeInModelCoordinates(), requestedRes);
         RasterImageLayer ril = new RasterImageLayer(outFile.getName(), context
                 .getWorkbenchContext().getLayerManager(),

--- a/src/org/openjump/core/ui/plugin/layer/pirolraster/LoadSextanteRasterImagePlugIn.java
+++ b/src/org/openjump/core/ui/plugin/layer/pirolraster/LoadSextanteRasterImagePlugIn.java
@@ -144,7 +144,7 @@ public class LoadSextanteRasterImagePlugIn extends AbstractPlugIn {
         plugInContext = context;
 		WorkbenchContext workbenchContext = context.getWorkbenchContext();
 		
-        RasterImageLayer.setWorkbenchContext(context.getWorkbenchContext());
+        //RasterImageLayer.setWorkbenchContext(context.getWorkbenchContext());
         
         if (context.getWorkbenchContext().getLayerViewPanel() == null){
             //logger.printWarning("rendering manager is NULL");

--- a/src/org/openjump/core/ui/plugin/layer/pirolraster/WarpImageToFencePlugIn.java
+++ b/src/org/openjump/core/ui/plugin/layer/pirolraster/WarpImageToFencePlugIn.java
@@ -112,7 +112,7 @@ public class WarpImageToFencePlugIn extends AbstractPlugIn {
 
         // Get whole image
         ImageAndMetadata imageAndMetadata = rasterImageIO.loadImage(
-                context.getWorkbenchContext(), rLayer.getImageFileName(),
+                /*context.getWorkbenchContext(),*/ rLayer.getImageFileName(),
                 rLayer.getMetadata().getStats(), null, null);
 
         ParameterBlock pb = new ParameterBlock();
@@ -145,7 +145,7 @@ public class WarpImageToFencePlugIn extends AbstractPlugIn {
         Resolution requestedRes = RasterImageIO
                 .calcRequestedResolution(viewport);
         imageAndMetadata = rasterImageIO.loadImage(
-                context.getWorkbenchContext(), outFile.getAbsolutePath(), null,
+                /*context.getWorkbenchContext(),*/ outFile.getAbsolutePath(), null,
                 viewport.getEnvelopeInModelCoordinates(), requestedRes);
         RasterImageLayer ril = new RasterImageLayer(outFile.getName(), context
                 .getWorkbenchContext().getLayerManager(),

--- a/src/org/openjump/core/ui/plugin/raster/ProfileGraphPlugIn.java
+++ b/src/org/openjump/core/ui/plugin/raster/ProfileGraphPlugIn.java
@@ -124,13 +124,13 @@ public class ProfileGraphPlugIn extends ThreadedBasePlugIn {
     private static RasterImageLayer rLayer;
     public static JTextField unitfiled = new JTextField("");
     public static MultiInputDialog dialog;
-    private final List<Coordinate> savedCoordinates = new ArrayList<Coordinate>();
-    JRadioButton radioButton1 = new JRadioButton(DRAWN, drawnType);
-    JRadioButton radioButton2 = new JRadioButton(SELECTED, selectedType);
+    private final List<Coordinate> savedCoordinates = new ArrayList<>();
+    //JRadioButton radioButton1 = new JRadioButton(DRAWN, drawnType);
+    //JRadioButton radioButton2 = new JRadioButton(SELECTED, selectedType);
     JComboBox<RasterImageLayer> box;
     JComboBox<String> comboBox = new JComboBox<String>();
-    JPanel panel1 = new JPanel(new FlowLayout());
-    JLabel label1;
+    //JPanel panel1 = new JPanel(new FlowLayout());
+    //JLabel label1;
 
     @Override
     public void initialize(PlugInContext context) throws Exception {
@@ -186,7 +186,7 @@ public class ProfileGraphPlugIn extends ThreadedBasePlugIn {
         String srs = "";
         for (final RasterImageLayer currentLayer : rlayers) {
             try {
-                srs = currentLayer.getSRSInfo().getUnit().toString();
+                srs = currentLayer.getSrsInfo().getUnit().toString();
             } catch (final Exception e) {
                 srs = "metre";
             }
@@ -199,7 +199,7 @@ public class ProfileGraphPlugIn extends ThreadedBasePlugIn {
                 .toArray()[0];
         String srsCode;
         try {
-            srsCode = firstElement.getSRSInfo().getUnit().toString();
+            srsCode = firstElement.getSrsInfo().getUnit().toString();
         } catch (final Exception e) {
             srsCode = "Unknown";
         }
@@ -236,7 +236,7 @@ public class ProfileGraphPlugIn extends ThreadedBasePlugIn {
         box.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                final String layerUnit = getLayer().getSRSInfo().getUnit()
+                final String layerUnit = getLayer().getSrsInfo().getUnit()
                         .toString();
 
                 unitfiled.setText(layerUnit);
@@ -244,12 +244,7 @@ public class ProfileGraphPlugIn extends ThreadedBasePlugIn {
                 dialog.repaint();
             }
         });
-        cpan.addActionListener(new java.awt.event.ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                color = cpan.getColor();
-            }
-        });
+        cpan.addActionListener(evt -> color = cpan.getColor());
         cpan.setColor(color);
         cpan.setAlpha(255);
         dialog.addRow("CheckColor", new JLabel(COLOR + " (" + PLOT + ")"),
@@ -257,7 +252,7 @@ public class ProfileGraphPlugIn extends ThreadedBasePlugIn {
     }
 
     public void updateComponents() {
-        final String layerUnit = getLayer().getSRSInfo().getUnit().toString();
+        final String layerUnit = getLayer().getSrsInfo().getUnit().toString();
         comboBox.setEnabled(layerUnit.equals("Unknown"));
         comboBox.setSelectedItem(layerUnit);
 
@@ -325,12 +320,10 @@ public class ProfileGraphPlugIn extends ThreadedBasePlugIn {
 
             final Collection<Feature> features = context.getLayerViewPanel()
                     .getSelectionManager().getFeaturesWithSelectedItems();
-            if (features.size() == 0 || features.size() > 1) {
-                context.getWorkbenchFrame()
-                        .warnUser(
-                                I18N.getMessage(
-                                        "com.vividsolutions.jump.workbench.plugin.Exactly-n-features-must-be-selected", //$NON-NLS-1$
-                                        new Object[] { 1 }));
+            if (features.size() != 1) {
+                context.getWorkbenchFrame().warnUser(I18N.getMessage(
+                        "com.vividsolutions.jump.workbench.plugin.Exactly-n-features-must-be-selected", 1
+                        ));
 
             } else {
                 final Geometry geom = features.iterator().next().getGeometry();

--- a/src/org/openjump/core/ui/plugin/raster/VectorizeToContoursPlugIn.java
+++ b/src/org/openjump/core/ui/plugin/raster/VectorizeToContoursPlugIn.java
@@ -292,10 +292,8 @@ public class VectorizeToContoursPlugIn extends ThreadedBasePlugIn {
         final FeatureSchema fs = new FeatureSchema();
         fs.addAttribute("geometry", AttributeType.GEOMETRY);
         fs.addAttribute(sValue, AttributeType.DOUBLE);
-        FeatureCollection featDataset = new FeatureDataset(fs);
-
-        featDataset = VectorizeAlgorithm.toContours(gwrapper, contMin, contMax,
-                contIntv, sValue, 0);
+        FeatureCollection featDataset = VectorizeAlgorithm
+                .toContours(gwrapper, contMin, contMax, contIntv, sValue, 0);
 
         final Layer vlayer = context.addLayer(StandardCategoryNames.WORKING,
                 rstLayer.getName() + "_" + "vectorized", featDataset);
@@ -331,7 +329,7 @@ public class VectorizeToContoursPlugIn extends ThreadedBasePlugIn {
         final Resolution requestedRes = RasterImageIO
                 .calcRequestedResolution(viewport);
         final ImageAndMetadata imageAndMetadata = rasterImageIO.loadImage(
-                context.getWorkbenchContext(), inputFile.getAbsolutePath(),
+                /*context.getWorkbenchContext(),*/ inputFile.getAbsolutePath(),
                 null, viewport.getEnvelopeInModelCoordinates(), requestedRes);
         final RasterImageLayer ril = new RasterImageLayer(inputFile.getName(),
                 context.getLayerManager(), inputFile.getAbsolutePath(),
@@ -356,7 +354,7 @@ public class VectorizeToContoursPlugIn extends ThreadedBasePlugIn {
                         1, RasterImageLayer.class)).add(new EnableCheck() {
                     @Override
                     public String check(JComponent component) {
-                        final List<RasterImageLayer> mLayer = new ArrayList<RasterImageLayer>();
+                        final List<RasterImageLayer> mLayer = new ArrayList<>();
                         final Collection<RasterImageLayer> rlayers = workbenchContext
                                 .getLayerManager().getLayerables(
                                         RasterImageLayer.class);

--- a/src/org/openjump/core/ui/plugin/tools/generate/RasterizePlugIn.java
+++ b/src/org/openjump/core/ui/plugin/tools/generate/RasterizePlugIn.java
@@ -17,7 +17,6 @@ import java.awt.GridBagLayout;
 import java.awt.Point;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.geom.NoninvertibleTransformException;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -38,7 +37,6 @@ import org.openjump.core.rasterimage.ImageAndMetadata;
 import org.openjump.core.rasterimage.RasterImageIO;
 import org.openjump.core.rasterimage.RasterImageLayer;
 import org.openjump.core.rasterimage.Resolution;
-import org.openjump.core.rasterimage.TiffTags.TiffReadingException;
 import org.openjump.core.rasterimage.algorithms.RasterizeAlgorithm;
 import org.openjump.core.ui.io.file.FileNameExtensionFilter;
 import org.saig.core.gui.swing.sldeditor.util.FormUtils;
@@ -320,7 +318,7 @@ public class RasterizePlugIn extends AbstractPlugIn
         jButton_Dir.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent evt) {
-                File outputPathFile = null;
+                File outputPathFile;
                 final JFileChooser chooser = new GUIUtil.FileChooserWithOverwritePrompting();
                 chooser.setDialogTitle(getName());
                 chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
@@ -348,8 +346,7 @@ public class RasterizePlugIn extends AbstractPlugIn
     }
     
 	 public static void load(File file, PlugInContext context, String category)
-	            throws NoninvertibleTransformException, TiffReadingException,
-	            Exception {
+	            throws Exception {
 
 	        RasterImageIO rasterImageIO = new RasterImageIO();
 	        Viewport viewport = context.getWorkbenchContext().getLayerViewPanel()
@@ -357,7 +354,7 @@ public class RasterizePlugIn extends AbstractPlugIn
 	        Resolution requestedRes = RasterImageIO
 	                .calcRequestedResolution(viewport);
 	        ImageAndMetadata imageAndMetadata = rasterImageIO.loadImage(
-	                context.getWorkbenchContext(), file.getAbsolutePath(), null,
+	                /*context.getWorkbenchContext(),*/ file.getAbsolutePath(), null,
 	                viewport.getEnvelopeInModelCoordinates(), requestedRes);
 	         Point point = RasterImageIO.getImageDimensions(file.getAbsolutePath());
 	       Envelope env = RasterImageIO.getGeoReferencing(file.getAbsolutePath(),


### PR DESCRIPTION
from Mike via Re: [JPP-Devel] OpenJUMP 2 refactoring layerable hierarchy

a rather big change in improve_layerable_hierarchy branch

Main modifications are :
1/ introduction of GeoReferencedLayerable, abstract class extending AbstractLayerable 
and wrapping Blackboard, Envelope and SRSInfo implemented by 
- Layer 
- RasterImageLayer
- WMSLayer

2/ elimination of WorkbenchContext reference in many classes and constructors related to
RasterImageLayer (trying to follow OOP principles like encapsulation or separation of concerns) 

I did not check if It still works with Sextante or  OpenKlem though.

Let me know if you think it can be merged as is or if it needs tests with some particular extensions

before being merge.