### PR TITLE
Logging upgrade part 1: Consistently use the internal workbench.Logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ target/
 hs_err_pid*
 /bin/
 
+# IntelliJ IDE config files
+.idea/
+
 .okhttpcache/*
 .settings/*
 .classpath

--- a/src/com/vividsolutions/jump/workbench/Logger.java
+++ b/src/com/vividsolutions/jump/workbench/Logger.java
@@ -120,9 +120,14 @@ public class Logger {
    * @param msg message to log
    * @param t throwable to log
    * @param logLevel log level of the message
-   * @param calledFrom Exception stacktracle
+   * @param calledFrom Exception stacktrace
    */
-  public static void log(String msg, Throwable t, Level logLevel,
+
+  public static void log(String msg, Throwable t, LogLevel logLevel, StackTraceElement calledFrom) {
+    log(msg, t, logLevel.getEquivalent(), calledFrom);
+  }
+
+  private static void log(String msg, Throwable t, Level logLevel,
       StackTraceElement calledFrom) {
 
     // get caller
@@ -234,12 +239,12 @@ public class Logger {
   /**
    * @return the current log level for the calling class
    */
-  public static Level getLevel() {
+  public static LogLevel getLevel() {
     // get caller
     StackTraceElement element = getCaller(new Exception().getStackTrace()[0]);
     org.apache.log4j.Logger logger = org.apache.log4j.Logger.getLogger(element
         .getClassName());
-    return logger.getEffectiveLevel();
+    return LogLevel.fromEquivalent(logger.getEffectiveLevel());
   }
 
   private static boolean isLoggerLevelEnabled(Level level) {
@@ -272,6 +277,32 @@ public class Logger {
 
   public static boolean isTraceEnabled() {
     return isLoggerLevelEnabled(Level.TRACE);
+  }
+
+  public enum LogLevel {
+    OFF(Level.OFF),
+    FATAL(Level.FATAL),
+    ERROR(Level.ERROR),
+    WARN(Level.WARN),
+    INFO(Level.INFO),
+    DEBUG(Level.DEBUG),
+    TRACE(Level.TRACE),
+    ALL(Level.ALL);
+
+    public static LogLevel fromEquivalent(Level equivalent) {
+      return valueOf(equivalent.toString());
+    }
+
+    private final Level equivalent;
+
+    LogLevel(Level equivalent) {
+      this.equivalent = equivalent;
+    }
+
+    private Level getEquivalent() {
+      return equivalent;
+    }
+
   }
 
 }

--- a/src/com/vividsolutions/jump/workbench/ui/SchemaPanel.java
+++ b/src/com/vividsolutions/jump/workbench/ui/SchemaPanel.java
@@ -76,13 +76,13 @@ import javax.swing.event.TableModelListener;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumn;
 
-import org.apache.log4j.Logger;
 import org.openjump.core.ui.util.FeatureSchemaUtils;
 
 import org.locationtech.jts.util.Assert;
 import com.vividsolutions.jump.I18N;
 import com.vividsolutions.jump.feature.AttributeType;
 import com.vividsolutions.jump.workbench.JUMPWorkbench;
+import com.vividsolutions.jump.workbench.Logger;
 import com.vividsolutions.jump.workbench.WorkbenchContext;
 import com.vividsolutions.jump.workbench.model.CategoryEvent;
 import com.vividsolutions.jump.workbench.model.FeatureEvent;
@@ -345,14 +345,13 @@ public class SchemaPanel extends JPanel {
 
             } catch (final Exception ex) {
 
-                final Logger LOG = Logger.getLogger(this.getClass());
                 JUMPWorkbench
                         .getInstance()
                         .getFrame()
                         .warnUser(
                                 this.getClass().getSimpleName() + " " + Error
                                         + ": " + ex.toString());
-                LOG.error(this.getClass().getName() + " " + Error + ": ", ex);
+                Logger.error(this.getClass().getName() + " " + Error + ": ", ex);
                 JOptionPane.showMessageDialog(JUMPWorkbench.getInstance()
                         .getFrame(), Error + ": " + ex, getName(), 0);
             }

--- a/src/com/vividsolutions/jump/workbench/ui/WorkbenchFrame.java
+++ b/src/com/vividsolutions/jump/workbench/ui/WorkbenchFrame.java
@@ -97,6 +97,7 @@ import com.vividsolutions.jump.util.CollectionUtil;
 import com.vividsolutions.jump.util.StringUtil;
 import com.vividsolutions.jump.workbench.JUMPWorkbench;
 import com.vividsolutions.jump.workbench.Logger;
+import com.vividsolutions.jump.workbench.Logger.LogLevel;
 import com.vividsolutions.jump.workbench.WorkbenchContext;
 import com.vividsolutions.jump.workbench.model.Category;
 import com.vividsolutions.jump.workbench.model.CategoryEvent;
@@ -613,7 +614,7 @@ public class WorkbenchFrame extends JFrame implements LayerViewPanelContext,
      */
     @Deprecated
     public void log(String message) {
-        Logger.info(message);
+        log(message, null, new Exception().getStackTrace()[0]);
     }
 
     /**
@@ -623,7 +624,7 @@ public class WorkbenchFrame extends JFrame implements LayerViewPanelContext,
      */
     @Deprecated
     public void log(String message, Class clazz) {
-        Logger.info(message);
+        log(message, null, new Exception().getStackTrace()[0]);
     }
 
     /**
@@ -632,7 +633,11 @@ public class WorkbenchFrame extends JFrame implements LayerViewPanelContext,
      */
     @Deprecated
     public void log(String message, Throwable t) {
-        Logger.info(message, t);
+        log(message, t, new Exception().getStackTrace()[0]);
+    }
+
+    private void log(String message, Throwable t, StackTraceElement calledFrom) {
+        Logger.log(message, Logger.isDebugEnabled() ? t : null, LogLevel.INFO, calledFrom);
     }
 
     public void setMinimumFeatureExtentForAnyRenderingInPixels(
@@ -1936,7 +1941,7 @@ public class WorkbenchFrame extends JFrame implements LayerViewPanelContext,
                         return;
                     }
                 } catch (Exception e) {
-                    Logger.info(e);
+                    log("", e);
                 }
 
                 // There are other internal frames associated with this task

--- a/src/com/vividsolutions/jump/workbench/ui/WorkbenchFrame.java
+++ b/src/com/vividsolutions/jump/workbench/ui/WorkbenchFrame.java
@@ -80,7 +80,6 @@ import javax.swing.event.PopupMenuListener;
 import javax.swing.text.JTextComponent;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Level;
 import org.openjump.core.CheckOS;
 import org.openjump.core.model.TaskEvent;
 import org.openjump.core.model.TaskListener;
@@ -614,7 +613,7 @@ public class WorkbenchFrame extends JFrame implements LayerViewPanelContext,
      */
     @Deprecated
     public void log(String message) {
-        log(message, null, new Exception().getStackTrace()[0]);
+        Logger.info(message);
     }
 
     /**
@@ -624,7 +623,7 @@ public class WorkbenchFrame extends JFrame implements LayerViewPanelContext,
      */
     @Deprecated
     public void log(String message, Class clazz) {
-        log(message, null, new Exception().getStackTrace()[0]);
+        Logger.info(message);
     }
 
     /**
@@ -633,11 +632,7 @@ public class WorkbenchFrame extends JFrame implements LayerViewPanelContext,
      */
     @Deprecated
     public void log(String message, Throwable t) {
-        log(message, t, new Exception().getStackTrace()[0]);
-    }
-
-    private void log(String message, Throwable t, StackTraceElement calledFrom) {
-        Logger.log(message, Logger.isDebugEnabled() ? t : null, Level.INFO, calledFrom);
+        Logger.info(message, t);
     }
 
     public void setMinimumFeatureExtentForAnyRenderingInPixels(
@@ -1941,7 +1936,7 @@ public class WorkbenchFrame extends JFrame implements LayerViewPanelContext,
                         return;
                     }
                 } catch (Exception e) {
-                    log("", e);
+                    Logger.info(e);
                 }
 
                 // There are other internal frames associated with this task

--- a/src/org/openjump/core/rasterimage/styler/RasterLegendPlugIn.java
+++ b/src/org/openjump/core/rasterimage/styler/RasterLegendPlugIn.java
@@ -22,7 +22,6 @@ import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 
-import org.apache.log4j.Logger;
 import org.openjump.core.apitools.LayerTools;
 import org.openjump.core.rasterimage.RasterImageLayer;
 import org.openjump.core.rasterimage.RasterSymbology;
@@ -40,6 +39,7 @@ import org.locationtech.jts.geom.Envelope;
 import com.vividsolutions.jump.I18N;
 import com.vividsolutions.jump.task.TaskMonitor;
 import com.vividsolutions.jump.workbench.JUMPWorkbench;
+import com.vividsolutions.jump.workbench.Logger;
 import com.vividsolutions.jump.workbench.WorkbenchContext;
 import com.vividsolutions.jump.workbench.plugin.EnableCheckFactory;
 import com.vividsolutions.jump.workbench.plugin.MultiEnableCheck;
@@ -365,13 +365,12 @@ public class RasterLegendPlugIn implements ThreadedPlugIn {
     }
 
     public static void Logger(Class<?> plugin, Exception e) {
-        final Logger LOG = Logger.getLogger(plugin);
         JUMPWorkbench
                 .getInstance()
                 .getFrame()
                 .warnUser(
                         plugin.getSimpleName() + " Exception: " + e.toString());
-        LOG.error(plugin.getName() + " Exception: ", e);
+        Logger.error(plugin.getName() + " Exception: ", e);
     }
 
     protected void saved(File file) {

--- a/src/org/openjump/core/ui/plugin/wms/WMSLegendPlugIn.java
+++ b/src/org/openjump/core/ui/plugin/wms/WMSLegendPlugIn.java
@@ -27,13 +27,13 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
 import org.openjump.core.apitools.LayerTools;
 import org.openjump.core.ui.io.file.FileNameExtensionFilter;
 import org.openjump.core.ui.swing.DetachableInternalFrame;
 
 import com.vividsolutions.jump.I18N;
 import com.vividsolutions.jump.workbench.JUMPWorkbench;
+import com.vividsolutions.jump.workbench.Logger;
 import com.vividsolutions.jump.workbench.WorkbenchContext;
 import com.vividsolutions.jump.workbench.model.WMSLayer;
 import com.vividsolutions.jump.workbench.plugin.AbstractPlugIn;
@@ -213,13 +213,12 @@ public class WMSLegendPlugIn extends AbstractPlugIn {
     }
 
     public static void Logger(Class<?> plugin, Exception e) {
-        final Logger LOG = Logger.getLogger(plugin);
         JUMPWorkbench
                 .getInstance()
                 .getFrame()
                 .warnUser(
                         plugin.getSimpleName() + " Exception: " + e.toString());
-        LOG.error(plugin.getName() + " Exception: ", e);
+        Logger.error(plugin.getName() + " Exception: ", e);
     }
 
     protected void saved(File file) {

--- a/src/org/openjump/sextante/gui/additionalResults/AdditionalResultsFrame.java
+++ b/src/org/openjump/sextante/gui/additionalResults/AdditionalResultsFrame.java
@@ -46,7 +46,6 @@ import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreePath;
 import javax.xml.namespace.QName;
 
-import org.apache.log4j.Logger;
 import org.math.plot.PlotPanel;
 import org.math.plot.plots.Plot;
 import org.openjump.core.apitools.IOTools;
@@ -58,6 +57,7 @@ import org.openjump.sextante.core.ObjectAndDescription;
 import com.vividsolutions.jump.I18N;
 import com.vividsolutions.jump.feature.FeatureCollection;
 import com.vividsolutions.jump.workbench.JUMPWorkbench;
+import com.vividsolutions.jump.workbench.Logger;
 import com.vividsolutions.jump.workbench.WorkbenchContext;
 import com.vividsolutions.jump.workbench.model.Task;
 import com.vividsolutions.jump.workbench.ui.FeatureCollectionPanel;
@@ -663,13 +663,12 @@ public class AdditionalResultsFrame extends DetachableInternalFrame {
     }
 
     public static void Logger(Class<?> plugin, Exception e) {
-        final Logger LOG = Logger.getLogger(plugin);
         JUMPWorkbench
                 .getInstance()
                 .getFrame()
                 .warnUser(
                         plugin.getSimpleName() + " Exception: " + e.toString());
-        LOG.error(plugin.getName() + " Exception: ", e);
+        Logger.error(plugin.getName() + " Exception: ", e);
     }
 
     protected JPanel getOKSavePanel() {

--- a/src/org/openjump/sextante/gui/additionalResults/AdditionalResultsIO.java
+++ b/src/org/openjump/sextante/gui/additionalResults/AdditionalResultsIO.java
@@ -30,7 +30,6 @@ import javax.xml.namespace.QName;
 
 import org.apache.batik.dom.svg.SVGDOMImplementation;
 import org.apache.batik.svggen.SVGGraphics2D;
-import org.apache.log4j.Logger;
 import org.math.plot.PlotPanel;
 import org.math.plot.plots.Plot;
 import org.openjump.core.apitools.IOTools;
@@ -43,6 +42,7 @@ import org.w3c.dom.Document;
 import com.vividsolutions.jump.I18N;
 import com.vividsolutions.jump.feature.FeatureCollection;
 import com.vividsolutions.jump.workbench.JUMPWorkbench;
+import com.vividsolutions.jump.workbench.Logger;
 import com.vividsolutions.jump.workbench.WorkbenchContext;
 import com.vividsolutions.jump.workbench.model.Task;
 import com.vividsolutions.jump.workbench.ui.FeatureCollectionPanel;
@@ -361,13 +361,12 @@ public class AdditionalResultsIO {
 	}
 
 	public static void Logger(Class<?> plugin, Exception e) {
-		final Logger LOG = Logger.getLogger(plugin);
 		JUMPWorkbench
 		.getInstance()
 		.getFrame()
 		.warnUser(
 				plugin.getSimpleName() + " Exception: " + e.toString());
-		LOG.error(plugin.getName() + " Exception: ", e);
+		Logger.error(plugin.getName() + " Exception: ", e);
 	}
 
 


### PR DESCRIPTION
This is the first step towards resolving https://github.com/openjump-gis/openjump/issues/49

Only the workbench.Logger class should be aware of the logging implementation used (currently Log4j 1, will be upgraded to Log4j 2 soon).

There were 6 classes directly using the Log4j 1 logging implementation. Those classes now use the internal workbench.Logger class.

I also expanded the .gitignore for IntelliJ IDE config files, to prevent accidentally committing those.