### PR TITLE
Minimal upgrade of srid.txt

### DIFF
--- a/src/org/openjump/core/ccordsys/utils/srid.txt
+++ b/src/org/openjump/core/ccordsys/utils/srid.txt
@@ -2532,6 +2532,7 @@
 <4902>;<NDG (Paris)>;[degree]
 <4903>;<Madrid 1870 (Madrid)>;[degree]
 <4904>;<Lisbon 1890 (Lisbon)>;[degree]
+<4978>;<WGS 84>;[metre]
 <5659>;<Monte Mario / UTMRER>;[metre]
 <5819>;<EPSG topocentric example A>;[metre]
 <5820>;<EPSG topocentric example B>;[metre]


### PR DESCRIPTION
I found that there was no code for EPSG:4978. This gives an idea how old is our code: EPSG:4328 was deprecated since 2004 when it was replaced with EPSG:4978