### PR TITLE
Upgraded Raster Tools to version 2.05

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -340,8 +340,8 @@
                      <goal>wget</goal>
                    </goals>
                    <configuration>
-                     <url>https://sourceforge.net/projects/opensit/files/Openjump/PlugIn/Raster%20Tools/RasterTools-2.0.4-20221210.jar</url>
-                     <sha1>1b05ff1ecb9bd0b3a53b058524dd428bb1aca980</sha1>
+                     <url>https://sourceforge.net/projects/opensit/files/Openjump/PlugIn/Raster%20Tools/RasterTools-2.0.5-20230201.jar</url>
+                     <sha1>4a7053b4f72b2d4a27d25db4515057dd9d5be1c4</sha1>
                      <unpack>false</unpack>
                      <outputDirectory>${plus.folder}</outputDirectory>
                    </configuration>


### PR DESCRIPTION
Upgraded Raster Tools to version 2.05. The new version implements Spatial reference System into TIFF file export and allows to reproject raster and image files between different coordinate reference systems.  Delaunay triangulation plugin: added a set of methods in order to cover a wide set of vector to raster transformation (Nearest Neighbor, Inverse Distance Weighted, Min Z, Mazx Z and Mean Z). The Info and Style plugin are grouped together as one plugin. Removed from the extension file the embedded JEP library. Raster tools works with both OpenJUMP Core and Plus, but Raster Calculator plugin is deactivated if JEP library are not available as in OJ Core.