### PR TITLE
Deactivated the numeric limit of Layer info

### DIFF
--- a/src/org/openjump/core/ui/plugin/layer/NewLayerPropertiesPlugIn.java
+++ b/src/org/openjump/core/ui/plugin/layer/NewLayerPropertiesPlugIn.java
@@ -423,10 +423,10 @@ public class NewLayerPropertiesPlugIn extends AbstractPlugIn {
             }
             // LAYER EXTENSION section
             info = info + header("", EXTENT);
-            info = info + property(XMIN, df.format(extent.getMinX()), bgColor0);
-            info = info + property(XMAX, df.format(extent.getMaxX()), bgColor1);
-            info = info + property(YMIN, df.format(extent.getMinY()), bgColor0);
-            info = info + property(YMAX, df.format(extent.getMaxY()), bgColor1);
+            info = info + property(XMIN, ""+extent.getMinX(), bgColor0);
+            info = info + property(XMAX, ""+extent.getMaxX(), bgColor1);
+            info = info + property(YMIN, ""+extent.getMinY(), bgColor0);
+            info = info + property(YMAX, ""+extent.getMaxY(), bgColor1);
             // FEATURES and ATTRIBUTES section
             info = info + header("", FEATURES);
             info = info


### PR DESCRIPTION
Deactivated  the numeric limit (by decimal format) of the Layer.class info related to geographic extension. The previus commit doesn't giv e exact values if  the image is in geographic coordinates (ex. EPSG4326). With this patch, the accuracy of the infomation, is retrieve directly from the values of the Envelope using JTS. 
As explained   in a former request for RasterImageLayer (#90), this correction can be useful to get information from a Image (in this case loaded via Layer.class) in order to manually modifyr tags into a KML file to obtain the correct position.