### PR TITLE
RasterImageLayer: added capability to read coordinates from .aux.xml file

### DIFF
--- a/src/language/jump.properties
+++ b/src/language/jump.properties
@@ -2964,6 +2964,7 @@ ui.zoom.ZoomToCoordinatePlugIn.enter-two-values=Enter two values!
 ui.zoom.ZoomToCoordinatePlugIn.{0}-is-not-a-number=''{0}'' is not a number!
 org.openjump.core.ccordsys.No-srs=No SRS info recorded from data source
 org.openjump.core.ccordsys.Embedded-srs=SRS info is included in data source
+org.openjump.core.ccordsys.AuxFile-srs=SRS info is included into an auxiliary file
 org.openjump.core.ccordsys.Not-consistent-srs=Warning: SRS info accompanying data source is not consistent with layer SRID
 ui.GenericNames.MODIFIED-LAYERS=Modified layers
 ui.GenericNames.TEMPORARY-LAYERS=Temporary layers

--- a/src/language/jump_es.properties
+++ b/src/language/jump_es.properties
@@ -3008,3 +3008,4 @@ org.openjump.core.ui.plugin.tools.MergeSelectedPolygonsWithNeighbourPlugIn.merge
 org.openjump.core.ui.plugin.tools.MergeSelectedPolygonsWithNeighbourPlugIn.minimum-area=#T:minimum area
 org.openjump.core.ui.plugin.tools.MergeSelectedPolygonsWithNeighbourPlugIn.Skip-null-values=#T:Skip features with null attribute value
 jump.features-processed=elementos procesados
+org.openjump.core.ccordsys.AuxFile-srs=SRS se incluye en un archivo auxiliar

--- a/src/language/jump_it.properties
+++ b/src/language/jump_it.properties
@@ -3009,3 +3009,4 @@ org.openjump.core.ui.plugin.tools.MergeSelectedPolygonsWithNeighbourPlugIn.merge
 org.openjump.core.ui.plugin.tools.MergeSelectedPolygonsWithNeighbourPlugIn.minimum-area=#T:minimum area
 org.openjump.core.ui.plugin.tools.MergeSelectedPolygonsWithNeighbourPlugIn.Skip-null-values=#T:Skip features with null attribute value
 jump.features-processed=elementi processati
+org.openjump.core.ccordsys.AuxFile-srs=SRS e' incluso in un file ausiliario

--- a/src/org/openjump/core/ccordsys/utils/ProjUtils.java
+++ b/src/org/openjump/core/ccordsys/utils/ProjUtils.java
@@ -48,6 +48,7 @@ public class ProjUtils {
     private static final String NO_SRS = I18N.getInstance().get("org.openjump.core.ccordsys.No-srs");
     private static final String EMBEDDED_SRS = I18N.getInstance().get("org.openjump.core.ccordsys.Embedded-srs");
     private static final String NOT_CONSISTENT_SRS = I18N.getInstance().get("org.openjump.core.ccordsys.Not-consistent-srs");
+    private static final String AUXFILE_SRS = I18N.getInstance().get("org.openjump.core.ccordsys.AuxFile-srs");
 
     /**
      * - Read SRS from GeoTIFF tag - This method gets projection srid code and
@@ -486,6 +487,7 @@ public class ProjUtils {
         // fallthrough
         if (srsInfo == null) {
             srsInfo = ProjUtils.getSRSInfoFromAuxiliaryFile(fileSourcePath);
+             srsInfo.setSource(AUXFILE_SRS);
         }
         // if srid=0 there must be no source for file projection.
         // if the layer is temporary (file saved into TEMP folder), srid source

--- a/src/org/openjump/core/rasterimage/GridAscii.java
+++ b/src/org/openjump/core/rasterimage/GridAscii.java
@@ -441,6 +441,14 @@ public class GridAscii {
         this.decimalPlaces = decimalPlaces;
     }
     
+    public Envelope getEnvelope() {
+    	Coordinate upperLeft = new Coordinate( xllCorner,
+    			yllCorner +  nRows *  cellSize);
+		Coordinate lowerRight = new Coordinate( xllCorner
+				+  nCols *  cellSize,  yllCorner);
+		return new Envelope(upperLeft, lowerRight);
+    }
+    
     private String ascFullFileName = null;
 
     private boolean origCorner = false;

--- a/src/org/openjump/core/rasterimage/GridFloat.java
+++ b/src/org/openjump/core/rasterimage/GridFloat.java
@@ -454,7 +454,15 @@ public class GridFloat {
     public float[] getFloatArray() {
         return dataArray;
     }
-
+    
+    public Envelope getEnvelope() {
+    	Coordinate upperLeft = new Coordinate( xllCorner,
+    			yllCorner +  nRows *  cellSize);
+		Coordinate lowerRight = new Coordinate( xllCorner
+				+  nCols *  cellSize,  yllCorner);
+		return new Envelope(upperLeft, lowerRight);
+    }
+    
     private String fltFullFileName = null;
     private String hdrFullFileName = null;
 

--- a/src/org/openjump/core/rasterimage/RasterImageIO.java
+++ b/src/org/openjump/core/rasterimage/RasterImageIO.java
@@ -152,11 +152,11 @@ public class RasterImageIO {
 
 			GridFloat gf = new GridFloat(fileNameOrURL);
 			gf.readGrid(null);
-
-			Envelope imageEnvelope = new Envelope(gf.getXllCorner(),
-					gf.getXllCorner() + gf.getnCols() * gf.getCellSize(),
-					gf.getYllCorner(), gf.getYllCorner() + gf.getnRows()
-							* gf.getCellSize());
+			Envelope imageEnvelope = gf.getEnvelope();
+		//	Envelope imageEnvelope = new Envelope(gf.getXllCorner(),
+		//			gf.getXllCorner() + gf.getnCols() * gf.getCellSize(),
+		//			gf.getYllCorner(), gf.getYllCorner() + gf.getnRows()
+		//					* gf.getCellSize());
 
 			stats = new Stats(1);
 			stats.setStatsForBand(0, gf.getMinVal(), gf.getMaxVal(),
@@ -173,11 +173,11 @@ public class RasterImageIO {
 
 			GridAscii ga = new GridAscii(fileNameOrURL);
 			ga.readGrid(null);
-
-			Envelope imageEnvelope = new Envelope(ga.getXllCorner(),
-					ga.getXllCorner() + ga.getnCols() * ga.getCellSize(),
-					ga.getYllCorner(), ga.getYllCorner() + ga.getnRows()
-							* ga.getCellSize());
+			Envelope imageEnvelope =ga.getEnvelope();
+			//Envelope imageEnvelope = new Envelope(ga.getXllCorner(),
+			//		ga.getXllCorner() + ga.getnCols() * ga.getCellSize(),
+			//		ga.getYllCorner(), ga.getYllCorner() + ga.getnRows()
+			//				* ga.getCellSize());
 
 			BufferedImage pImage = ga.getBufferedImage();
 

--- a/src/org/openjump/core/rasterimage/WorldFileHandler.java
+++ b/src/org/openjump/core/rasterimage/WorldFileHandler.java
@@ -274,4 +274,50 @@ public class WorldFileHandler implements HandlerToMakeYourLifeEasier{
     public String getWorldFileName() {
         return worldFileName;
     }
+    
+      /**
+     * Envelope from spatial reference  recored into an auxiliary (<fileName>.aux.xml) file
+     * @param auxFile. File path of the image (ex. C:/folder/myIMage.png)
+     * @param width. Width in pixel of the image file
+     * @param height. Height in pixel of the image file 
+     * @return Envelope
+     */
+      
+    public   Envelope auxFileEnvelope(String auxFile, int width, int height) {
+    	double A = 0, B = 0, C = 0, D = 0, E = 0, F = 0;
+			String coordinates = null;
+			Scanner scanner;
+			 try {
+				 scanner = new Scanner(new File(auxFile));
+			 } catch (FileNotFoundException e1) {
+				 return null;
+			 }
+			 String fileText = scanner.useDelimiter("\\A").next();
+			if(fileText.contains("<GeoTransform>")) {
+				Pattern pattern = Pattern.compile("<GeoTransform>(.*)</GeoTransform>");
+				Matcher matcher = pattern.matcher(fileText);
+				matcher.find();
+				coordinates= matcher.group(1);
+				coordinates = StringUtil.replaceAll(coordinates, ",", " ");
+				final StringTokenizer stringTokenizer = new StringTokenizer(coordinates);
+				C = Double.valueOf(stringTokenizer.nextToken());
+				A = Double.valueOf(stringTokenizer.nextToken());
+				D = Double.valueOf(stringTokenizer.nextToken());
+				F = Double.valueOf(stringTokenizer.nextToken());
+				B = Double.valueOf(stringTokenizer.nextToken());
+				E = Double.valueOf(stringTokenizer.nextToken());
+				double west = A * 0 + B * 0 + C;
+				double north = D * 0 + E * 0 + F;
+				double east = A * (width - 1) + B * (height - 1) + C;
+				double south = D * (width - 1) + E * (height - 1) + F;
+				final Coordinate upperLeft = new Coordinate(west, north);
+				final Coordinate lowerRight = new Coordinate(east, south);
+				return new Envelope(upperLeft, lowerRight);
+			} else {
+				return null;
+			}
+	
+	}
+    
+    
 }


### PR DESCRIPTION
This patch shoud give the ability to RasteImageLayer Framework to read coordinates from aux.xml file in absence of world file.
The process to generate the raster envelope is the following stages:
a) check auxiliary file and check <GeoTransform> tag to build the envelope
b) check world file to build the envelope
c) in case of a) and b) are not available or the envelopeis  null, try GeoTiff tags and ESRI FLT/ASC info.
d) Eventually it opens the dialog where the uses can input the coordinates of the envelope

Comparing to the previous version where a wold file was always build when a raster/image was open, this patch creates a world file only at the stage d)
