### PR TITLE
AttributeTable : non-editable cells are now selectable

### DIFF
--- a/src/com/vividsolutions/jump/workbench/ui/LayerTableModel.java
+++ b/src/com/vividsolutions/jump/workbench/ui/LayerTableModel.java
@@ -237,9 +237,9 @@ public class LayerTableModel extends ColumnBasedTableModel {
     }
 
     public boolean isCellEditable(int rowIndex, int columnIndex) {
-        if (!layer.isEditable()) {
-            return false;
-        }
+//        if (!layer.isEditable()) {
+//            return false;
+//        }
 
         if (getColumn(columnIndex) == fidColumn) {
             return false;
@@ -249,11 +249,11 @@ public class LayerTableModel extends ColumnBasedTableModel {
             return false;
         }
 
-		FeatureSchema schema = 
-			layer.getFeatureCollectionWrapper().getFeatureSchema();
-		if (schema.isAttributeReadOnly(schema.getAttributeIndex(getColumn(
-				columnIndex).getName())))
-			return false;
+//		FeatureSchema schema =
+//			layer.getFeatureCollectionWrapper().getFeatureSchema();
+//		if (schema.isAttributeReadOnly(schema.getAttributeIndex(getColumn(
+//				columnIndex).getName())))
+//			return false;
 
         return true;
     }

--- a/src/com/vividsolutions/jump/workbench/ui/LayerTableModel.java
+++ b/src/com/vividsolutions/jump/workbench/ui/LayerTableModel.java
@@ -237,9 +237,10 @@ public class LayerTableModel extends ColumnBasedTableModel {
     }
 
     public boolean isCellEditable(int rowIndex, int columnIndex) {
-//        if (!layer.isEditable()) {
-//            return false;
-//        }
+
+        // All columns use a CellEditor except fid and geometry so that text can be selected,
+        // Underlying JTextField can still be made editable or not editable
+        // depending on attributes (see also JTable.prepareEditor in AttributeTablePanel)
 
         if (getColumn(columnIndex) == fidColumn) {
             return false;
@@ -248,12 +249,6 @@ public class LayerTableModel extends ColumnBasedTableModel {
         if (getColumn(columnIndex) == geomButtonColumn) {
             return false;
         }
-
-//		FeatureSchema schema =
-//			layer.getFeatureCollectionWrapper().getFeatureSchema();
-//		if (schema.isAttributeReadOnly(schema.getAttributeIndex(getColumn(
-//				columnIndex).getName())))
-//			return false;
 
         return true;
     }


### PR DESCRIPTION
**Original request**
User request was to be able to copy/paste attribute value from AttributeTable, in the case of not editable layers.

**Use TableCellEditor instead of TableCellRenderer**
I could not make cell values selectable from the TableCellRenderer. Hence, to make selection/copy/paste possible TableCellEditor is now used in both cases of editable and non-editable layers.
To prevent edit operation in the non-editable layer case, the editable component is finalized (made editable or not) during the preparation phase of the component (prepareEditor).

**Other improvements**
Small improvements in the cell rendering (do not truncate letters anymore in edition mode) and in the popupmenu used to manage null values.