### PR TITLE
Update AddRasterImageLayerWizard.java

### DIFF
--- a/src/org/openjump/core/rasterimage/AddRasterImageLayerWizard.java
+++ b/src/org/openjump/core/rasterimage/AddRasterImageLayerWizard.java
@@ -215,6 +215,24 @@ public class AddRasterImageLayerWizard extends AbstractWizardGroup {
         } catch (Exception e) {
             Logger.error(e);
         }
+
+        	// [Giuseppe Aruta 2024_08_19]
+		// This part of code allows to read and apply a style to a RasterImageLayer.
+		// The style must be stored as SLD file with the same name of the layer.
+		if (rLayer.getNumBands() == 1) {// Currently OpenJUMP can read/write symbology only for
+			// monoband raster files
+			String sldS = new File(imageFileName).getAbsolutePath().replace("tif", "sld");
+			File sldFile = new File(sldS);
+			if (sldFile.exists() && !sldFile.isDirectory()) {
+				try {
+					RasterSymbology finalRasterSymbolizer = SLDHandler.read(sldFile);
+					rLayer.setSymbology(finalRasterSymbolizer);
+				} catch (Exception e) {
+					Logger.error("cannot decode sld file: " + e);
+				}
+			}
+
+		}
         // #################################
 
         final MetaInformationHandler mih = new MetaInformationHandler(rLayer);


### PR DESCRIPTION
This part of code allows to read and apply a style to a RasterImageLayer on loading.  The style must be stored as SLD file with the same name of the layer. Limited to DTM/DEM (monoband raster files) as OpenJUMP can actually read/write symbology only for  these types of file