### PR TITLE
Added ability to automatically apply a style to a loading RasterImageLayer from a sld file

### DIFF
--- a/src/org/openjump/core/rasterimage/AddRasterImageLayerWizard.java
+++ b/src/org/openjump/core/rasterimage/AddRasterImageLayerWizard.java
@@ -12,6 +12,7 @@ import javax.imageio.ImageIO;
 import com.vividsolutions.jump.workbench.Logger;
 import org.openjump.core.ccordsys.utils.ProjUtils;
 import org.openjump.core.ccordsys.utils.SRSInfo;
+import org.openjump.core.rasterimage.styler.SLDHandler;
 import org.openjump.core.ui.plugin.file.OpenRecentPlugIn;
 import org.openjump.core.ui.plugin.layer.pirolraster.RasterImageWizardPanel;
 import org.openjump.core.ui.swing.wizard.AbstractWizardGroup;
@@ -215,6 +216,25 @@ public class AddRasterImageLayerWizard extends AbstractWizardGroup {
         } catch (Exception e) {
             Logger.error(e);
         }
+         // [Giuseppe Aruta 2024_08_19]
+		// This part of code allows to read and apply a style to a RasterImageLayer.
+		// The style must be stored as SLD file with the same name of the layer.
+		if (rLayer.getNumBands() == 1) {// Currently OpenJUMP can read/write symbology only for
+			// monoband raster files
+			String sldS = new File(imageFileName).getAbsolutePath().replace("tif", "sld");
+			File sldFile = new File(sldS);
+			if (sldFile.exists() && !sldFile.isDirectory()) {
+				try {
+					RasterSymbology finalRasterSymbolizer = SLDHandler.read(sldFile);
+					rLayer.setSymbology(finalRasterSymbolizer);
+				} catch (Exception e) {
+					Logger.error("cannot decode sld file: " + e);
+				}
+			}
+
+		
+
+        
         // #################################
 
         final MetaInformationHandler mih = new MetaInformationHandler(rLayer);


### PR DESCRIPTION
This patch allows to read and apply a style to a RasterImageLayer on loading file.  The style must be stored as SLD file with the same name of the layer.  It is currently limited to single banded layer (DTM/DEM) as SLDHandler class can decode styles only for that type of layers