### PR TITLE
accept geojson as a valid file extension

### DIFF
--- a/src/com/vividsolutions/jump/io/datasource/StandardReaderWriterFileDataSource.java
+++ b/src/com/vividsolutions/jump/io/datasource/StandardReaderWriterFileDataSource.java
@@ -136,7 +136,7 @@ public abstract class StandardReaderWriterFileDataSource extends ReaderWriterFil
 
     public static class GeoJSON extends ClassicReaderWriterFileDataSource {
       public GeoJSON() {
-          super(new GeoJSONReader(), new GeoJSONWriter(), new String[] { "json" });
+          super(new GeoJSONReader(), new GeoJSONWriter(), new String[] { "json", "geojson" });
       }
     }
 


### PR DESCRIPTION
Accept "geojson" as a valid file extension for geojson (only json was accepted until now)